### PR TITLE
Allow options in getBlob* functions

### DIFF
--- a/src/utils/__tests__/azure_storage.test.ts
+++ b/src/utils/__tests__/azure_storage.test.ts
@@ -18,7 +18,7 @@ const TestObject = t.interface({
 type TestObject = t.TypeOf<typeof TestObject>;
 
 const blobServiceMock = {
-  getBlobToText: jest.fn((_, __, f) => {
+  getBlobToText: jest.fn((_, __, ___, f) => {
     f({
       code: BlobNotFoundCode
     });


### PR DESCRIPTION
Needed to pass the leaseId to lock the Blob.